### PR TITLE
Fix NSRangeException when removing load command

### DIFF
--- a/optool/operations.m
+++ b/optool/operations.m
@@ -265,6 +265,13 @@ BOOL removeLoadEntryFromBinary(NSMutableData *binary, struct thin_header macho, 
             case LC_LOAD_DYLIB: {
                 
                 struct dylib_command command = *(struct dylib_command *)(binary.bytes + binary.currentOffset);
+
+                // validate name's range offset is in binary bounds
+                if (binary.currentOffset + command.cmdsize > binary.length) {
+                    LOG("Command at offset %lu is out of binary bounds", binary.currentOffset);
+                    break;
+                }
+
                 char *name = (char *)[[binary subdataWithRange:NSMakeRange(binary.currentOffset + command.dylib.name.offset, command.cmdsize - command.dylib.name.offset)] bytes];
                 if ([@(name) isEqualToString:payload] && removedOrdinal == -1) {
                     LOG("removing payload from %s...", LC(cmd));


### PR DESCRIPTION
Fix exception when removing load command by validate name's range offset is in binary bounds.

Reproduce: `./optool uninstall -c load -p "{path_to_lc}"-t {target_binary}`

Found thin header...
removing payload from LC_LOAD_UPWARD_DYLIB...
*** Terminating app due to uncaught exception 'NSRangeException', reason: '*** -[NSConcreteMutableData subdataWithRange:]: range {1601335516, 33359580} exceeds data length 93552'
*** First throw call stack:
(
0 CoreFoundation 0x00007ff815ba185e __exceptionPreprocess + 242
1 libobjc.A.dylib 0x00007ff81569467f objc_exception_throw + 48
2 Foundation 0x00007ff816a18a53 -[NSProgress initWithParent:userInfo:] + 0
3 optool 0x0000000102afe11c removeLoadEntryFromBinary + 389
4 optool 0x0000000102afce22 main + 2679
5 dyld 0x0000000202e7f386 start + 1942
)
libc++abi: terminating due to uncaught exception of type NSException
[1] 57846 abort ./optool uninstall -c load -p "{path_to_lc}" -t